### PR TITLE
fix: Use the default AWS credential provider chain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,7 @@ gen-docs:
 # All gen targets
 .PHONY: gen
 gen: gen-docs
+
+.PHONY: serve
+serve:
+	AWS_PROFILE=deployTools go run main.go serve

--- a/client/client.go
+++ b/client/client.go
@@ -29,11 +29,14 @@ func New(ctx context.Context, logger zerolog.Logger, s specs.Source, opts source
 		return nil, fmt.Errorf("failed to unmarshal plugin spec: %w", err)
 	}
 
+	// Loads credentials from the default credential chain.
+	// Locally, set the AWS_PROFILE environment variable, or run `make serve`.
+	// See https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials.
 	cfg, err := config.LoadDefaultConfig(
 		ctx,
 		config.WithRegion("eu-west-1"),
-		config.WithSharedConfigProfile("deployTools"),
 	)
+
 	if err != nil {
 		return nil, fmt.Errorf("unable to load AWS config, %w", err)
 	}


### PR DESCRIPTION
## What does this change?
Since v1.1.3 this plugin has been failing to run, with the logs showing:

```log
failed to sync v1 source galaxies: rpc error: code = Unknown desc = failed to sync resources: failed to create execution client for source plugin guardian-galaxies: unable to load AWS config, failed to get shared config profile, deployTools
```

The [docs](https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-profiles) suggest calling `LoadDefaultConfig` with `WithSharedConfigProfile` as an argument will _augment_ the default credential provider chain. This does not appear to be happening. Instead it appears to be resetting it, with a single provider in the chain. Whilst this works locally, in production we want to use credentials from the ECS task, not a named profile.

In this change, prefer to use the vanilla implementation of `LoadDefaultConfig`, and use profile credentials via environment variables.

The change should result in the correct credentials being loaded locally, and in ECS.

<details><summary>Running locally</summary>
<p>

This change means to run the plugin locally we move from `go run main.go serve` to `AWS_PROFILE=deployTools go run main.go serve`. Or simply `make serve`.

</p>
</details> 