### PR TITLE
Fix gorelease action by removing deprecated options

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,11 +33,11 @@ jobs:
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --clean --skip-validate --skip-publish --skip-sign
+          args: release --clean --skip=validate,publish,sign
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --clean --skip-sign
+          args: release --clean --skip=sign
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fixes gorelease action by replacing deprecated `--skip-validate` (and others) with `--skip`. When we upgraded to the latest action in https://github.com/guardian/cq-source-galaxies/pull/25 these options were removed.

https://goreleaser.com/deprecations/#-skip