### PR TITLE
Update Dependabot schedule interval to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,14 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: quarterly
     commit-message:
       prefix: "chore(deps): "
 
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: monthly
+      interval: quarterly
     commit-message:
       prefix: "chore(deps): "
     groups:


### PR DESCRIPTION
## What does this change?

Updates the Dependabot schedule interval from the current value to `quarterly`, so dependency update PRs are raised on the first day of each quarter (January, April, July, October).

